### PR TITLE
Add some type annotations for jscompiler

### DIFF
--- a/iron-page-url.html
+++ b/iron-page-url.html
@@ -144,7 +144,7 @@ milliseconds.
       this.listen(window, 'hashchange', '_hashChanged');
       this.listen(window, 'location-changed', '_urlChanged');
       this.listen(window, 'popstate', '_urlChanged');
-      this.listen(document.body, 'click', '_globalOnClick');
+      this.listen(/** @type {!HTMLBodyElement} */(document.body), 'click', '_globalOnClick');
 
       this._urlChanged();
       this._initialized = true;
@@ -153,7 +153,7 @@ milliseconds.
       this.unlisten(window, 'hashchange', '_hashChanged');
       this.unlisten(window, 'location-changed', '_urlChanged');
       this.unlisten(window, 'popstate', '_urlChanged');
-      this.unlisten(document.body, 'click', '_globalOnClick');
+      this.unlisten(/** @type {!HTMLBodyElement} */(document.body), 'click', '_globalOnClick');
       this._initialized = false;
     },
     /**
@@ -272,7 +272,11 @@ milliseconds.
 
       // It only makes sense for us to intercept same-origin navigations.
       // pushState/replaceState don't work with cross-origin links.
-      var url = new URL(href, document.baseURI);
+      var url = new URL(href);
+      if (document.baseURI != null) {
+        url = new URL(href, /** @type {string} */(document.baseURI));
+      }
+
       if (url.origin !== window.location.origin) {
         return null;
       }

--- a/iron-page-url.html
+++ b/iron-page-url.html
@@ -272,9 +272,11 @@ milliseconds.
 
       // It only makes sense for us to intercept same-origin navigations.
       // pushState/replaceState don't work with cross-origin links.
-      var url = new URL(href);
+      var url;
       if (document.baseURI != null) {
         url = new URL(href, /** @type {string} */(document.baseURI));
+      } else {
+        url = new URL(href);
       }
 
       if (url.origin !== window.location.origin) {


### PR DESCRIPTION
* document.body should be defined by the time `attached()` and `detached()` run. 
* handle `document.baseURI` not existing a bit better