### PR TITLE
Fire a location-changed event whenever we update the URL.

### DIFF
--- a/iron-page-url.html
+++ b/iron-page-url.html
@@ -217,6 +217,7 @@ milliseconds.
       } else {
         window.history.pushState({}, '', newUrl);
       }
+      this.fire('location-changed', {}, {node: window});
     },
     /**
      * A necessary evil so that links work as expected. Does its best to

--- a/test/iron-page-url.html
+++ b/test/iron-page-url.html
@@ -19,6 +19,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../iron-page-url.html">
 </head>
 <body>
+<test-fixture id='Solo'>
+  <template>
+    <iron-page-url></iron-page-url>
+  </template>
+</test-fixture>
+<test-fixture id='Together'>
+  <template>
+    <div>
+      <iron-page-url id='one'></iron-page-url>
+      <iron-page-url id='two'></iron-page-url>
+    </div>
+  </template>
+</test-fixture>
+
 
 <script>
   'use strict';
@@ -64,11 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('when used solo', function() {
       var urlElem;
       setup(function() {
-        urlElem = document.createElement('iron-page-url');
-        urlElem.attached();
-      });
-      teardown(function() {
-        urlElem.detached();
+        urlElem = fixture('Solo');
       });
       test('basic functionality with #hash urls', function() {
         // Initialized to the window location's hash.
@@ -122,14 +132,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var otherUrlElem;
       var urlElem;
       setup(function() {
-        urlElem = document.createElement('iron-page-url');
-        urlElem.attached();
-        otherUrlElem = document.createElement('iron-page-url');
-        otherUrlElem.attached();
-      });
-      teardown(function() {
-        otherUrlElem.detached();
-        urlElem.detached();
+        var elems = fixture('Together');
+        urlElem = elems.querySelector('#one');
+        otherUrlElem = elems.querySelector('#two');
       });
       function assertHaveSameUrls(urlElemOne, urlElemTwo) {
         expect(urlElemOne.path).to.be.equal(urlElemTwo.path);

--- a/test/iron-page-url.html
+++ b/test/iron-page-url.html
@@ -118,6 +118,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             '?greeting=hello&target=world&another=key');
       });
     });
+    suite('when used with other iron-page-url elements', function() {
+      var otherUrlElem;
+      var urlElem;
+      setup(function() {
+        urlElem = document.createElement('iron-page-url');
+        urlElem.attached();
+        otherUrlElem = document.createElement('iron-page-url');
+        otherUrlElem.attached();
+      });
+      teardown(function() {
+        otherUrlElem.detached();
+        urlElem.detached();
+      });
+      function assertHaveSameUrls(urlElemOne, urlElemTwo) {
+        expect(urlElemOne.path).to.be.equal(urlElemTwo.path);
+        expect(urlElemOne.hash).to.be.equal(urlElemTwo.hash);
+        expect(urlElemOne.query).to.be.equal(urlElemTwo.query);
+      }
+      test('coordinate their changes (by firing events on window)', function() {
+        assertHaveSameUrls(urlElem, otherUrlElem);
+
+        urlElem.path = '/a/b/c';
+        assertHaveSameUrls(urlElem, otherUrlElem);
+
+        otherUrlElem.query = 'alsdkjflaksjfd=alksjfdlkajsdfl';
+        assertHaveSameUrls(urlElem, otherUrlElem);
+
+        urlElem.hash = 'lkjljifosjkldfjlksjfldsjf';
+        assertHaveSameUrls(urlElem, otherUrlElem);
+      });
+    });
   });
 
 </script>


### PR DESCRIPTION
Supports multiple iron-page-url elements working without direct coordination.

(I thought this was there already? I guess anything that isn't tested doesn't exist :)